### PR TITLE
Compatability with php 8.4

### DIFF
--- a/src/MoonPhase.php
+++ b/src/MoonPhase.php
@@ -48,7 +48,7 @@ class MoonPhase
     /**
      * @param DateTime|null $date
      */
-    public function __construct(DateTime $date = null)
+    public function __construct(?DateTime $date = null)
     {
         $date = null !== $date
             ? $date->getTimestamp()


### PR DESCRIPTION
Deprecate implicitly nullable parameter types
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types