### PR TITLE
Update constructor to use DateTimeInterface

### DIFF
--- a/src/MoonPhase.php
+++ b/src/MoonPhase.php
@@ -13,7 +13,7 @@
 
 namespace Solaris;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @see \Solaris\Tests\MoonPhaseTest
@@ -46,9 +46,9 @@ class MoonPhase
     protected float $ageDegrees;
 
     /**
-     * @param DateTime|null $date
+     * @param DateTimeInterface|null $date
      */
-    public function __construct(?DateTime $date = null)
+    public function __construct(?DateTimeInterface $date = null)
     {
         $date = null !== $date
             ? $date->getTimestamp()


### PR DESCRIPTION
Use DateTimeInterface insteadof DateTime.

It would allow use of DateTimeImmutable, nesbot/carbon, cakephp/chronos and others to be used in the constructor